### PR TITLE
ngraph to dot-graph transformation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,14 @@ graph.addLink(2, 3);
 var toDot = require('ngraph.todot');
 var dotContent = toDot(graph);
 // or
-var newGraph = fromDot(dotContent, {
+var dotContent = toDot(dotContent, {
   createNodeAttributes: (node) => ({label: node.data.text}),
   createLinkAttributes: (link) => ({label: link.data.value}),
+  directed: false, // Force the graph to be non-directed
+  graphAttributes: {
+    label: text,
+    ...
+  }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ graph.addLink(2, 3);
 // Now save it to dot format:
 var toDot = require('ngraph.todot');
 var dotContent = toDot(graph);
+// or
+var newGraph = fromDot(dotContent, {
+  createNodeAttributes: (node) => ({label: node.data.text}),
+  createLinkAttributes: (link) => ({label: link.data.value}),
+});
 ```
 
 This will set `dotContent` to a string with a graph, described in dot format:

--- a/index.js
+++ b/index.js
@@ -3,8 +3,10 @@ module.exports.write = write;
 
 function write(graph, writer, options) {
   if (!options) options = {}
+  var directed = options.directed !== undefined ? !!options.directed : true
+
   // we always assume it's directed graph for now.
-  writer('digraph G {');
+  writer(directed ? 'digraph G {' : 'graph G {');
   // very naive algorith. Will optimize in future if required;
   graph.forEachLink(storeLink);
   graph.forEachNode(storeNode);
@@ -14,7 +16,7 @@ function write(graph, writer, options) {
   function storeLink(link) {
     var fromId = dotEscape(link.fromId);
     var toId = dotEscape(link.toId);
-    var line = fromId + ' -> ' + toId;
+    var line = fromId + (directed ? ' -> ' : ' -- ') + toId;
     if (options.createLinkAttributes) {
       line += makeDotAttribute(options.createLinkAttributes(link));
     } else if (link.data !== undefined) {
@@ -65,7 +67,8 @@ function todot(graph, options) {
 
   write(graph, bufferWriter, {
     createNodeAttributes: options.createNodeAttributes,
-    createLinkAttributes: options.createLinkAttributes
+    createLinkAttributes: options.createLinkAttributes,
+    directed: options.directed
   });
 
   return buf.join('\n');

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 module.exports = todot;
 module.exports.write = write;
 
-function write(graph, writer) {
+function write(graph, writer, options) {
+  if (!options) options = {}
   // we always assume it's directed graph for now.
   writer('digraph G {');
   // very naive algorith. Will optimize in future if required;
@@ -13,11 +14,13 @@ function write(graph, writer) {
   function storeLink(link) {
     var fromId = dotEscape(link.fromId);
     var toId = dotEscape(link.toId);
-    var attribute = link.data === undefined ?
-          '' :
-          ' ' + makeDotAttribute(link.data);
-
-    writer(fromId + ' -> ' + toId + attribute);
+    var line = fromId + ' -> ' + toId;
+    if (options.createLinkAttributes) {
+      line += makeDotAttribute(options.createLinkAttributes(link));
+    } else if (link.data !== undefined) {
+      line += makeDotAttribute(link.data);
+    }
+    writer(line);
   }
 
   function makeDotAttribute(object) {
@@ -30,30 +33,39 @@ function write(graph, writer) {
         var value = JSON.stringify(object[attrName]);
         buf.push(dotEscape(attrName) + '=' + value);
       });
-      return '[' + buf.join(' ') + ']';
+      return ' [' + buf.join(' ') + ']';
     }
     // else - it's primitive type:
-    return '[' + JSON.stringify(object) + ']';
+    return ' [' + JSON.stringify(object) + ']';
   }
 
   function storeNode(node) {
     var links = graph.getLinks(node.id);
     var isIsolated = !links || (links.length === 0);
-    if (isIsolated) {
+    if (isIsolated || options.createNodeAttributes) {
       // non-isolated nodes are saved by `storeLink()`;
-      writer(dotEscape(node.id));
+      var line = dotEscape(node.id);
+      if (options.createNodeAttributes) {
+        line += makeDotAttribute(options.createNodeAttributes(node));
+      }
+      writer(line);
     }
   }
 }
 
-function todot(graph, indent) {
-  indent = typeof indent === 'number' ? indent : 0;
+function todot(graph, options) {
+  if (!options) options = {};
+
+  var indent = typeof options.indent === 'number' ? options.indent : 0;
   if (indent < 0) indent = 0;
 
   var prefix = new Array(indent + 1).join(' ');
   var buf = [];
 
-  write(graph, bufferWriter);
+  write(graph, bufferWriter, {
+    createNodeAttributes: options.createNodeAttributes,
+    createLinkAttributes: options.createLinkAttributes
+  });
 
   return buf.join('\n');
 
@@ -70,4 +82,3 @@ function dotEscape(id) {
   id = id.replace(/\n/gm, '\\\n');
   return '"' + id + '"';
 }
-

--- a/index.js
+++ b/index.js
@@ -30,8 +30,9 @@ function write(graph, writer, options) {
       // TODO: handle arrays properly
       var buf = [];
       Object.keys(object).forEach(function(attrName) {
-        var value = JSON.stringify(object[attrName]);
-        buf.push(dotEscape(attrName) + '=' + value);
+        var value = object[attrName];
+        var isHTML = typeof value == 'string' && value[0] == '<' && value[value.length - 1] == '>';
+        buf.push(dotEscape(attrName) + '=' + (isHTML ? value : JSON.stringify(object[attrName])));
       });
       return ' [' + buf.join(' ') + ']';
     }


### PR DESCRIPTION
Added transformation functions in order to choose dot attributes from the node/link objects.
/!\ Breaks the original argument order for `indent`, as it is now nested into the `options` object.
If you need backward compatibility, you may have a special case if `options` is found to be an integer.